### PR TITLE
Feature/ab#2217 configurable roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ spring.security.oauth2.client.registration.keycloak.client-id=aicockpit
 spring.security.oauth2.client.registration.keycloak.client-secret=aicockpit
 spring.security.oauth2.client.registration.keycloak.scope=openid
 ```
+__Authorization / Role Mapping__
+
+This application needs users to be in certain roles. Internally these roles are admin, user, reader. As these names are very generic, app supports arbitrary names to be mapped to these three internal roles. Mapping is configured as follows:
+```properties
+security.rolemapping.admin=visualizer_admin
+security.rolemapping.user=visualizer_user
+security.rolemapping.reader=visualizer_reader
+```
 
 ## License
 Software in this repository is licensed under the AGPL-3.0 license. See [license agreement](LICENSE) for more details.

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -39,7 +39,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
-        </dependency>	
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -76,6 +76,16 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>
+						-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+						-Xshare:off
+					</argLine>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>

--- a/application/src/main/java/de/starwit/SaeVisualizerApplication.java
+++ b/application/src/main/java/de/starwit/SaeVisualizerApplication.java
@@ -4,10 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-
-@SpringBootApplication(exclude = {
-	org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class,
-	org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration.class })
+@SpringBootApplication
 @EnableScheduling
 public class SaeVisualizerApplication {
 

--- a/application/src/main/java/de/starwit/config/CustomClientRegistration.java
+++ b/application/src/main/java/de/starwit/config/CustomClientRegistration.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 
 import jakarta.validation.constraints.NotBlank;
 
@@ -64,6 +65,7 @@ public class CustomClientRegistration {
             .scope(scope)
             .clientId(clientId)
             .clientSecret(clientSecret)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
             .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
             .redirectUri(redirectUri)
             .providerConfigurationMetadata(Map.of("end_session_endpoint", endSessionEndpoint))

--- a/application/src/main/java/de/starwit/config/CustomClientRegistration.java
+++ b/application/src/main/java/de/starwit/config/CustomClientRegistration.java
@@ -12,7 +12,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
-import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/application/src/main/java/de/starwit/config/NoSecurityConfig.java
+++ b/application/src/main/java/de/starwit/config/NoSecurityConfig.java
@@ -1,0 +1,23 @@
+package de.starwit.config;
+
+import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Profile({ "dev" })
+@Configuration
+public class NoSecurityConfig {
+
+    @Bean
+    SecurityFilterChain actuatorSecurity(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher(EndpointRequest.toAnyEndpoint())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable());
+
+        return http.build();
+    }
+}

--- a/application/src/main/java/de/starwit/config/RoleMapper.java
+++ b/application/src/main/java/de/starwit/config/RoleMapper.java
@@ -1,0 +1,35 @@
+package de.starwit.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoleMapper {
+
+    @Value("${security.rolemapping.admin:visualizer_admin}")
+    String adminRoleName;
+
+    @Value("${security.rolemapping.user:visualizer_user}")
+    String userRoleName;
+
+    @Value("${security.rolemapping.reader:visualizer_reader}")
+    String readerRoleName;
+
+    public List<String> mapAllRoles(List<String> externalRoles) {
+        return externalRoles.stream().map(this::mapRole).toList();
+    }
+
+    private String mapRole(String externalRole) {
+        if (externalRole.equals(adminRoleName)) {
+            return "admin";
+        } else if (externalRole.equals(userRoleName)) {
+            return "user";
+        } else if (externalRole.equals(readerRoleName)) {
+            return "reader";
+        } else {
+            return externalRole;
+        }
+    }
+}

--- a/application/src/main/java/de/starwit/config/SecurityConfig.java
+++ b/application/src/main/java/de/starwit/config/SecurityConfig.java
@@ -14,7 +14,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.lang.NonNull;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -24,6 +26,8 @@ import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMap
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
@@ -32,7 +36,7 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
 import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -43,8 +47,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
-
-@Profile({"auth", "auth-dev"})
+@Profile({ "auth", "auth-dev" })
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
@@ -55,8 +58,8 @@ public class SecurityConfig {
     private ClientRegistrationRepository clientRegistrationRepository;
 
     LogoutSuccessHandler oidcLogoutSuccessHandler() {
-        OidcClientInitiatedLogoutSuccessHandler oidcLogoutSuccessHandler =
-                new OidcClientInitiatedLogoutSuccessHandler(this.clientRegistrationRepository);
+        OidcClientInitiatedLogoutSuccessHandler oidcLogoutSuccessHandler = new OidcClientInitiatedLogoutSuccessHandler(
+                this.clientRegistrationRepository);
 
         // Sets the location that the End-User's User Agent will be redirected to
         // after the logout has been performed at the Provider
@@ -67,23 +70,39 @@ public class SecurityConfig {
     }
 
     @Bean
+    @Order(10)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(httpSecurityCsrfConfigurer -> httpSecurityCsrfConfigurer
-                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
-            .addFilterAfter(new CsrfCookieFilter(), BasicAuthenticationFilter.class)
-            .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/monitoring/health", "/manifest.json").permitAll()
-                .requestMatchers("/**").hasAnyRole("admin", "user", "reader")
-                .anyRequest().authenticated())
-            .logout(logout -> logout
-                .logoutSuccessHandler(oidcLogoutSuccessHandler())
-                .logoutRequestMatcher(new AntPathRequestMatcher("/logout")))
-            // Maybe
-            // https://stackoverflow.com/questions/74939220/classnotfoundexception-org-springframework-security-oauth2-server-resource-web
-            .oauth2Login(Customizer.withDefaults());
+                .csrf(httpSecurityCsrfConfigurer -> httpSecurityCsrfConfigurer
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
+                .addFilterAfter(new CsrfCookieFilter(), BasicAuthenticationFilter.class)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/monitoring/health", "/manifest.json").permitAll()
+                        .requestMatchers("/**").hasAnyRole("admin", "user", "reader")
+                        .anyRequest().authenticated())
+                .logout(logout -> logout
+                        .logoutSuccessHandler(oidcLogoutSuccessHandler())
+                        .logoutRequestMatcher(PathPatternRequestMatcher.withDefaults()
+                                .matcher(HttpMethod.GET, "/logout")))
+                // Maybe
+                // https://stackoverflow.com/questions/74939220/classnotfoundexception-org-springframework-security-oauth2-server-resource-web
+                .oauth2Login(Customizer.withDefaults())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
         return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        Converter<Jwt, Collection<GrantedAuthority>> grantedAuthoritiesConverter = jwt -> {
+            @SuppressWarnings("unchecked")
+            List<String> tokenRoles = (List<String>) jwt.getClaimAsMap("realm_access").get("roles");
+            return tokenRoles.stream().map(r -> (GrantedAuthority) new SimpleGrantedAuthority("ROLE_" + r)).toList();
+        };
+
+        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(grantedAuthoritiesConverter);
+        return jwtAuthenticationConverter;
     }
 
     // Taken from
@@ -176,7 +195,8 @@ final class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler 
 final class CsrfCookieFilter extends OncePerRequestFilter {
 
     @Override
-    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain)
             throws ServletException, IOException {
         CsrfToken csrfToken = (CsrfToken) request.getAttribute("_csrf");
         // Render the token value to a cookie by causing the deferred token to be loaded

--- a/application/src/main/java/de/starwit/config/SecurityConfig.java
+++ b/application/src/main/java/de/starwit/config/SecurityConfig.java
@@ -15,7 +15,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
-import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -26,8 +25,6 @@ import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMap
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
@@ -87,22 +84,8 @@ public class SecurityConfig {
                                 .matcher(HttpMethod.GET, "/logout")))
                 // Maybe
                 // https://stackoverflow.com/questions/74939220/classnotfoundexception-org-springframework-security-oauth2-server-resource-web
-                .oauth2Login(Customizer.withDefaults())
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+                .oauth2Login(Customizer.withDefaults());
         return http.build();
-    }
-
-    @Bean
-    public JwtAuthenticationConverter jwtAuthenticationConverter() {
-        Converter<Jwt, Collection<GrantedAuthority>> grantedAuthoritiesConverter = jwt -> {
-            @SuppressWarnings("unchecked")
-            List<String> tokenRoles = (List<String>) jwt.getClaimAsMap("realm_access").get("roles");
-            return tokenRoles.stream().map(r -> (GrantedAuthority) new SimpleGrantedAuthority("ROLE_" + r)).toList();
-        };
-
-        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
-        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(grantedAuthoritiesConverter);
-        return jwtAuthenticationConverter;
     }
 
     // Taken from
@@ -110,6 +93,9 @@ public class SecurityConfig {
     @Component
     @RequiredArgsConstructor
     static class GrantedAuthoritiesMapperImpl implements GrantedAuthoritiesMapper {
+
+        @Autowired
+        private RoleMapper roleMapper;
 
         @SuppressWarnings("unchecked")
         @Override
@@ -130,7 +116,8 @@ public class SecurityConfig {
                             LOG.error("claims do not contain 'realm_access' map");
                             return;
                         }
-                        final List<String> roles = (List<String>) realmAccessMap.get("roles");
+                        List<String> roles = (List<String>) realmAccessMap.get("roles");
+                        roles = roleMapper.mapAllRoles(roles);
 
                         mappedAuthorities.addAll(
                                 roles.stream().map(role -> new SimpleGrantedAuthority("ROLE_" + role)).toList());

--- a/application/src/main/resources/application-auth-dev.properties
+++ b/application/src/main/resources/application-auth-dev.properties
@@ -3,3 +3,7 @@ spring.security.oauth2.client.provider.keycloak.issuer-uri=http://auth.markus-wo
 spring.security.oauth2.client.registration.keycloak.client-id=aicockpit
 spring.security.oauth2.client.registration.keycloak.client-secret=aicockpit
 spring.security.oauth2.client.registration.keycloak.scope=openid
+
+# security.rolemapping.admin=visualizer_admin
+# security.rolemapping.user=visualizer_user
+# security.rolemapping.reader=visualizer_reader

--- a/application/src/main/resources/application-auth.properties
+++ b/application/src/main/resources/application-auth.properties
@@ -10,3 +10,7 @@
 # oidc-client-registration.client-id=aicockpit
 # oidc-client-registration.client-secret=aicockpit
 # oidc-client-registration.redirect-uari={baseUrl}/login/oauth2/code/{registrationId}
+
+# security.rolemapping.admin=visualizer_admin
+# security.rolemapping.user=visualizer_user
+# security.rolemapping.reader=visualizer_reader

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-spring.profiles.active=dev
 
 spring.application.name=sae-visualizer
 server.servlet.context-path=/sae-visualizer

--- a/application/src/test/java/de/starwit/SAEVisualizerApplicationTests.java
+++ b/application/src/test/java/de/starwit/SAEVisualizerApplicationTests.java
@@ -3,7 +3,7 @@ package de.starwit;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = SaeVisualizerApplication.class)
 class SAEVisualizerApplicationTests {
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>4.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>de.starwit</groupId>
@@ -20,9 +20,9 @@
 	</scm>
 
 	<properties>
-		<java.version>21</java.version>
-		<spring.version>3.5.5</spring.version>
-		<openapi-version>2.8.13</openapi-version>
+		<java.version>25</java.version>
+		<spring.version>4.0.6</spring.version>
+		<openapi-version>3.0.3</openapi-version>
 		<lettuce.version>6.8.1.RELEASE</lettuce.version>
 	</properties>
 


### PR DESCRIPTION
App now supports arbitrary external role names, that are mapped to standard internal role names.

## Description
Application needs users to have one of three roles admin, user, reader. External names can now mapped via application.properties.

## Motivation and Context
Standard role names are very generic and hard to use in multi application scenarios. Thus this PR presents a mapping mechanism.

## How has this been tested?
Local Keycloak with sample users.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
